### PR TITLE
Add RandoUtils Mod to fix softlocks on bosses

### DIFF
--- a/UE4SS/RandoUtils/scripts/bloodstainedUtils.lua
+++ b/UE4SS/RandoUtils/scripts/bloodstainedUtils.lua
@@ -1,0 +1,15 @@
+function ValidUObjectOrNil(uObject)
+    if uObject ~= nil and uObject:IsValid() then return uObject end
+    return nil
+end
+
+local gameInstanceCache
+---@return UPBGameInstance?
+function GetGameInstance()
+    if ValidUObjectOrNil(gameInstanceCache) == nil then
+        ---@type UPBGameInstance?
+        gameInstanceCache = ValidUObjectOrNil(FindFirstOf("PBGameInstance"))
+    end
+
+    return gameInstanceCache
+end

--- a/UE4SS/RandoUtils/scripts/main.lua
+++ b/UE4SS/RandoUtils/scripts/main.lua
@@ -1,0 +1,70 @@
+require("utils")
+require("bloodstainedUtils")
+
+local checkedBosses = { "N1003", "N2013", "N2001" }
+local warpBossDestinations = { ["N2001"] = "m09TRN_003" }
+local hasWarpSucceeded = false
+
+---@param warpTarget string
+function WarpTo(warpTarget)
+    if hasWarpSucceeded then return end
+
+    ExecuteInGameThread(function()
+        ---@type UPBGameInstance?
+        local gameInstance = ValidUObjectOrNil(GetGameInstance())
+        if gameInstance == nil then
+            Print("GameInstance was invalid, cancelling warp")
+            return
+        end
+        local currentRoom = gameInstance.pRoomManager:GetCurrentRoomId():ToString()
+        if currentRoom == warpTarget then
+            hasWarpSucceeded = true
+            return
+        end
+
+        gameInstance.pRoomManager:Warp(FName(warpTarget), true, true, FName("None"), { A = 1, R = 0, G = 0, B = 0 })
+
+        --Try again, in case warp failed
+        ExecuteWithDelay(2000, function()
+            WarpTo(warpTarget)
+        end)
+    end)
+end
+
+function EndBoss(currentBoss, bossName)
+    currentBoss:EndBossBattle()
+
+    if warpBossDestinations[bossName] == nil then return end
+
+    ExecuteWithDelay(20000, function()
+        hasWarpSucceeded = false
+        WarpTo(warpBossDestinations[bossName])
+    end)
+end
+
+function UnlockRoomIfCurrentBossDeadLoop()
+    ExecuteWithDelay(1000, UnlockRoomIfCurrentBossDeadLoop)
+    ExecuteInGameThread(function()
+        local gameInstance = GetGameInstance()
+        if gameInstance == nil then
+            Print("Game instance invalid")
+            return
+        end
+
+        ---@type APBBaseCharacter?
+        local currentBoss = ValidUObjectOrNil(gameInstance.CurrentBoss)
+        if currentBoss == nil then return end
+
+        local bossName = currentBoss:GetBossId():ToString()
+        if not TableContains(checkedBosses, bossName) then return end
+
+        if currentBoss:GetHitPoint() > 0 then return end
+
+        ExecuteWithDelay(8500, function()
+            EndBoss(currentBoss, bossName)
+        end)
+    end)
+end
+
+Print("Mod loaded")
+UnlockRoomIfCurrentBossDeadLoop()

--- a/UE4SS/RandoUtils/scripts/utils.lua
+++ b/UE4SS/RandoUtils/scripts/utils.lua
@@ -1,0 +1,14 @@
+function TableContains(table, value)
+    for i = 1, #table do
+        if (table[i] == value) then
+            return true
+        end
+    end
+    return false
+end
+
+function Print(...)
+    local param = tostring(...)
+    if (...).ToString ~= nil then param = (...):ToString() end
+    print("[RandoUtils] " .. param .. "\n")
+end


### PR DESCRIPTION
Added RandoUtils mod to the repo

For now, it detects if we're in one of the three boss fights that softlock the game in randomizer, and manually ends the boss battle after a delay, to make sure that the player collects the shard

For Glutton Train, it warps the player after ending the fight with a long delay, since the boss is actually considered dead as soon as Zangetsu pulls the mask off, and not when it crystallizes