### PR TITLE
Fix build warnings due to un-escaped single backslashes in strings

### DIFF
--- a/Graphic.py
+++ b/Graphic.py
@@ -314,7 +314,7 @@ def import_texture(filename):
     
     root = os.getcwd()
     os.chdir("Tools\\UE4 DDS Tools")
-    os.system(f"cmd /c python\python.exe src\main.py \"{absolute_asset_dir}\\{filename}.uasset\" \"{absolute_texture_dir}\\{filename}.dds\" --save_folder=\"{absolute_mod_dir}\" --mode=inject --version=4.22")
+    os.system(f"cmd /c python\\python.exe src\\main.py \"{absolute_asset_dir}\\{filename}.uasset\" \"{absolute_texture_dir}\\{filename}.dds\" --save_folder=\"{absolute_mod_dir}\" --mode=inject --version=4.22")
     os.chdir(root)
     
     #UE4 DDS Tools does not interrupt the program if a texture fails to convert so do it from here

--- a/Randomizer.py
+++ b/Randomizer.py
@@ -620,7 +620,7 @@ class Generate(QThread):
         self.progress_bar.setLabelText("Packing files...")
         
         with open("Tools\\UnrealPak\\filelist.txt", "w") as file_writer:
-            file_writer.write("\"Mod\*.*\" \"..\..\..\*.*\" \n")
+            file_writer.write("\"Mod\\*.*\" \"..\\..\\..\\*.*\" \n")
         
         root = os.getcwd()
         os.chdir("Tools\\UnrealPak")
@@ -1388,7 +1388,7 @@ class MainWindow(QWidget):
         #Text field
         
         self.starting_items_field = QLineEdit(config.get("StartWith", "sStartItem"))
-        self.starting_items_field.setToolTip("Items to start with. Input their english names with\ncommas as separators. If unsure refer to the files\nin Data\Translation for item names.")
+        self.starting_items_field.setToolTip("Items to start with. Input their english names with\ncommas as separators. If unsure refer to the files\nin Data\\Translation for item names.")
         self.starting_items_field.textChanged[str].connect(self.starting_items_field_changed)
         center_box_16_layout.addWidget(self.starting_items_field, 0, 0)
         
@@ -1400,7 +1400,7 @@ class MainWindow(QWidget):
         center_box_13_layout.addWidget(self.param_string_field, 0, 0)
         
         self.game_path_field = QLineEdit(config.get("Misc", "sGamePath"))
-        self.game_path_field.setToolTip("Path to your game's data (...\steamapps\common\Bloodstained Ritual of the Night).")
+        self.game_path_field.setToolTip("Path to your game's data (...\\steamapps\\common\\Bloodstained Ritual of the Night).")
         self.game_path_field.textChanged[str].connect(self.game_path_field_changed)
         center_box_14_layout.addWidget(self.game_path_field, 0, 0)
         
@@ -2382,7 +2382,7 @@ class MainWindow(QWidget):
         #Check if path is valid
         
         if not self.is_game_path_valid():
-            self.notify_error("Game path invalid, input the path to your game's data\n(...\steamapps\common\Bloodstained Ritual of the Night).")
+            self.notify_error("Game path invalid, input the path to your game's data\n(...\\steamapps\\common\\Bloodstained Ritual of the Night).")
             return
         
         #Check AP incompatibility
@@ -2555,7 +2555,7 @@ class MainWindow(QWidget):
         #Check if path is valid
         
         if not self.is_game_path_valid():
-            self.notify_error("Game path invalid, input the path to your game's data\n(...\steamapps\common\Bloodstained Ritual of the Night).")
+            self.notify_error("Game path invalid, input the path to your game's data\n(...\\steamapps\\common\\Bloodstained Ritual of the Night).")
             return
         
         self.import_assets(list(Manager.file_to_path), self.import_finished)

--- a/System.py
+++ b/System.py
@@ -12,7 +12,7 @@ import colorsys
 
 from enum import Enum
 from collections import OrderedDict
-s
+
 sys.path.append(os.path.abspath("Tools\\UAssetAPI"))
 clr.AddReference("UAssetSnippet")
 clr.AddReference("UAssetAPI")

--- a/System.py
+++ b/System.py
@@ -12,7 +12,7 @@ import colorsys
 
 from enum import Enum
 from collections import OrderedDict
-
+s
 sys.path.append(os.path.abspath("Tools\\UAssetAPI"))
 clr.AddReference("UAssetSnippet")
 clr.AddReference("UAssetAPI")


### PR DESCRIPTION
Quick fix for the current build warnings due to single backslashes in strings