### PR TITLE
Downgrade PySide to 6.6 due to import * issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ psutil == 5.9.*
 pythonnet == 3.0.*
 requests == 2.31.*
 vdf == 3.4
-PySide6 == 6.7.*
+PySide6 == 6.6.*
 pyinstaller == 6.5.*


### PR DESCRIPTION
PySide 6.7 has type errors when using import *
View: 
 - https://forum.qt.io/topic/155934/pyside6-7-is-majorly-broken-typeerrors-everywhere/8
 - https://bugreports.qt.io/browse/PYSIDE-2674